### PR TITLE
Optionally disable parent process check in wtmplogger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ LDFLAGS ?=
 EXES = sftpwrapper wtmplogger
 COMMON_HEADERS = logger.h proc_pid_util.h config.h
 COMMON_MODULES = config.c proc_pid_util.c
+WTMPLOGGER_EXTRA_FLAGS ?=
 
 all:	$(EXES)
 
@@ -11,7 +12,7 @@ sftpwrapper: sftpwrapper.c $(COMMON_MODULES) $(COMMON_HEADERS)
 	$(CC) $(CFLAGS) -o $@ $< $(COMMON_MODULES) $(LDFLAGS)
 
 wtmplogger: wtmplogger.c $(COMMON_MODULES) $(COMMON_HEADERS)
-	$(CC) $(CFLAGS) -o $@ $< $(COMMON_MODULES) $(LDFLAGS) -lutil
+	$(CC) $(CFLAGS) $(WTMPLOGGER_EXTRA_FLAGS) -o $@ $< $(COMMON_MODULES) $(LDFLAGS) -lutil
 
 clean:
 	rm -f $(EXES)


### PR DESCRIPTION
You may disable the check by compiling the code with:

WTMPLOGGER_EXTRA_FLAGS="-DWTMPLOGGER_NO_PARENT_PROCESS_CHECK" make

This can be useful in a container environment where /proc/PID/exe is
not available for all processes.

It is discouraged to use this option.